### PR TITLE
Feeature: Don't poll redis every x seconds

### DIFF
--- a/player.go
+++ b/player.go
@@ -3,13 +3,15 @@
 package soundwave
 
 import (
-	"time"
 	"fmt"
 	"io/ioutil"
 	"log"
+	"time"
 
 	"github.com/op/go-libspotify/spotify"
 )
+
+var Playing bool = false
 
 const (
 	APPLICATION_NAME  string = "SFM_"
@@ -22,8 +24,8 @@ var StopTrack chan struct{}
 var StopTimer chan struct{}
 
 type Ticker struct {
-	duration  int
-	step      int
+	duration int
+	step     int
 }
 
 func (t *Ticker) Start() {
@@ -53,14 +55,13 @@ func NewTicker() *Ticker {
 	return &Ticker{}
 }
 
-
 // Soundwave player, handles holding the connection to Spotify and
 // playing tracks
 type Player struct {
-	Audio        *audioWriter
-	Session      *spotify.Session
-	Player       *spotify.Player
-	TrackTicker  *Ticker
+	Audio       *audioWriter
+	Session     *spotify.Session
+	Player      *spotify.Player
+	TrackTicker *Ticker
 }
 
 // Constructs a new player taking the Spotify user, password and key path
@@ -188,6 +189,7 @@ func (p *Player) Play(uri *string) error {
 	log.Println(fmt.Sprintf("Playing: %s", *uri))
 	p.Player.Play() // This does NOT block, we must block ourselves
 	p.TrackTicker.Start()
+	Playing = true
 
 	// Runs a loop which increases track duration every second
 	go p.tickerIncreaser()
@@ -198,20 +200,22 @@ func (p *Player) Play(uri *string) error {
 
 	<-StopTrack // Blocks
 	StopTimer <- struct{}{}
+	Playing = false
+
 	log.Println(fmt.Sprintf("End: %s", *uri))
 
 	return nil
 }
 
 // Increase ticker duration
-func (p *Player) tickerIncreaser() (error) {
+func (p *Player) tickerIncreaser() error {
 	for {
 		tick := time.Tick(1 * time.Second)
 		select {
-			case <-StopTimer:
-				return nil
-			case <-tick:
-				p.TrackTicker.Increase()
+		case <-StopTimer:
+			return nil
+		case <-tick:
+			p.TrackTicker.Increase()
 		}
 	}
 }
@@ -236,11 +240,11 @@ func (p *Player) Resume() {
 	p.TrackTicker.Play()
 }
 
-func (p *Player) IsPlaying() (bool) {
+func (p *Player) IsPlaying() bool {
 	return p.TrackTicker.step > 0
 }
 
-func (p *Player) CurrentElapsedTime() (int) {
+func (p *Player) CurrentElapsedTime() int {
 	return p.TrackTicker.duration
 }
 

--- a/player.go
+++ b/player.go
@@ -11,8 +11,6 @@ import (
 	"github.com/op/go-libspotify/spotify"
 )
 
-var Playing bool = false
-
 const (
 	APPLICATION_NAME  string = "SFM_"
 	CACHE_LOCATION    string = "tmp"
@@ -189,7 +187,6 @@ func (p *Player) Play(uri *string) error {
 	log.Println(fmt.Sprintf("Playing: %s", *uri))
 	p.Player.Play() // This does NOT block, we must block ourselves
 	p.TrackTicker.Start()
-	Playing = true
 
 	// Runs a loop which increases track duration every second
 	go p.tickerIncreaser()
@@ -200,8 +197,6 @@ func (p *Player) Play(uri *string) error {
 
 	<-StopTrack // Blocks
 	StopTimer <- struct{}{}
-	Playing = false
-
 	log.Println(fmt.Sprintf("End: %s", *uri))
 
 	return nil

--- a/playlist.go
+++ b/playlist.go
@@ -5,8 +5,8 @@ package soundwave
 import (
 	"encoding/json"
 	"log"
-	"time"
 	"strconv"
+	"time"
 
 	"github.com/op/go-libspotify/spotify"
 
@@ -62,27 +62,42 @@ func NewPlaylist(k string, c string, r *redis.Client, p *Player) *Playlist {
 // or the track is stopped
 func (p *Playlist) Watch() {
 	for {
-		tick := time.Tick(1 * time.Second)
-		select {
-		case <-tick:
-			// If we are not logged in then we won't try and play a tack, we will try
-			// again on the next tick
-			if p.Player.Session.ConnectionState() == spotify.ConnectionStateLoggedIn {
-				value, err := p.RedisClient.LPop(p.RedisKeyName).Result()
-				if err == redis.Nil {
-					// Key does not exist so no items on the queue, no need to log this, would be
-					// very vebose
-				} else if err != nil {
-					log.Println(err)
-				} else {
-					// Play the item we just popped off the list
-					p.play(value) // Blocks
-				}
+		if p.Player.Session.ConnectionState() == spotify.ConnectionStateLoggedIn {
+			// Get the next track of the queue
+			track, err := p.GetNext()
+
+			// We have a track and no err so play
+			if track != "" && err == nil {
+				p.play(track) // Blocks
+			}
+
+			// Track is nil so we have no more items in the queue so
+			// lets wait for a track to be added before we go around
+			// again
+			if track == "" && err == nil {
+				log.Println("Waitng for Add Track Event")
+				<-AddTrack // Blocks
+			}
+
+			// We got an err from Redis, lets just log it
+			if err != nil {
+				log.Println(err)
 			}
 		}
 	}
 }
 
+// Pop track of the top of the queue returning the value of the key or nil
+func (p *Playlist) GetNext() (string, error) {
+	value, err := p.RedisClient.LPop(p.RedisKeyName).Result()
+	if err == redis.Nil {
+		return "", nil // No key so no queue
+	} else if err != nil {
+		return "", err
+	} else {
+		return value, nil
+	}
+}
 
 // Publish current tract duration into redis
 func (p *Playlist) CurrentTrackDurationPublisher() {

--- a/reactor.go
+++ b/reactor.go
@@ -15,12 +15,8 @@ import (
 	"gopkg.in/redis.v3"
 )
 
-// Channel for add track eveents
-var AddTrack chan struct{}
-
 // Events we need to listen for
 const (
-	ADD_EVENT    string = "add"    // Add track to queue event
 	RESUME_EVENT string = "resume" // Resume paused track
 	PAUSE_EVENT  string = "pause"  // Pause a playing track
 	STOP_EVENT   string = "stop"   // Stop the currently playing track
@@ -45,9 +41,6 @@ type Reactor struct {
 // - Pointer to Redis Client
 // - Pointer to Player  TODO: Remove and switch to channel notification
 func NewReactor(c string, r *redis.Client, p *Player) *Reactor {
-	// Make our Add Track Channel
-	AddTrack = make(chan struct{}, 1)
-	// Return a new Reactor
 	return &Reactor{
 		RedisChannelName: c,
 		RedisClient:      r,
@@ -102,8 +95,6 @@ func (r *Reactor) processPayload(payload []byte) error {
 
 	// Switch the event type and hand off to handler method
 	switch e.Type {
-	case ADD_EVENT:
-		return r.addTrack()
 	case PAUSE_EVENT:
 		return r.pausePlayer()
 	case RESUME_EVENT:
@@ -113,18 +104,6 @@ func (r *Reactor) processPayload(payload []byte) error {
 	}
 
 	return nil
-}
-
-// A track was added to the player
-func (r *Reactor) addTrack() error {
-	log.Println("Add Event")
-
-	if !Playing && len(AddTrack) == 0 {
-		log.Println("Unblock AddTrack")
-		AddTrack <- struct{}{}
-	}
-
-	return nil // always return nil since no errors can happen here
 }
 
 // Pause the Player


### PR DESCRIPTION
This feature removes the polling of the redis queue and instead uses the `BLPOP` feature of Redis. This will block until an item is placed on the queue, forever.
