### PR TITLE
Feature: Prefetch track on add to playlist

### DIFF
--- a/playlist.go
+++ b/playlist.go
@@ -84,12 +84,10 @@ func (p *Playlist) prefetch() error {
 	var err error
 
 	// Get next item in list, returns a list
-	result, err := p.RedisClient.LRange(p.RedisKeyName, 0, 0).Result()
+	result, err := p.RedisClient.LRange(p.RedisKeyName, 1, 1).Result()
 	if err != nil {
 		return err
 	}
-
-	log.Println(result)
 
 	// If we have a next track then lets prefetch it whilst the current one plays
 	if len(result) == 1 {


### PR DESCRIPTION
This PR adds the prefetch functionality to the add event. This does make the prefetch on next somewhat obsolete but thought I would leave it in as a failsafe.

I also fixed a bug where the next prefetch would get the current track rather than the next one.
